### PR TITLE
Adding Geometry criteria to queries

### DIFF
--- a/ArcGIS.ServiceModel/Operation/Query.cs
+++ b/ArcGIS.ServiceModel/Operation/Query.cs
@@ -41,12 +41,31 @@ namespace ArcGIS.ServiceModel.Operation
         [DataMember(Name = "outFields")]
         public String OutFields { get; set; }
 
+        /// <summary>
+        /// The geometry to apply as the spatial filter.
+        /// The structure of the geometry is the same as the structure of the json geometry objects returned by the ArcGIS REST API.
+        /// In addition to the JSON structures, for envelopes and points, you can specify the geometry with a simpler comma-separated syntax.
+        /// </summary>
+        /// <remarks>Default is empty</remarks>
         [DataMember(Name = "geometry")]
         public IGeometry Geometry { get; set; }
 
+        /// <summary>
+        /// The type of geometry specified by the geometry parameter. 
+        /// The geometry type can be an envelope, point, line, or polygon.
+        /// The default geometry type is "esriGeometryEnvelope". 
+        /// Values: esriGeometryPoint | esriGeometryMultipoint | esriGeometryPolyline | esriGeometryPolygon | esriGeometryEnvelope
+        /// </summary>
+        /// <remarks>Default is esriGeometryEnvelope</remarks>
         [DataMember(Name = "geometryType")]
         public string GeometryType { get; set; }
 
+        /// <summary>
+        /// The spatial relationship to be applied on the input geometry while performing the query.
+        /// The supported spatial relationships include intersects, contains, envelope intersects, within, etc.
+        /// The default spatial relationship is "esriSpatialRelIntersects".
+        /// Values: esriSpatialRelIntersects | esriSpatialRelContains | esriSpatialRelCrosses | esriSpatialRelEnvelopeIntersects | esriSpatialRelIndexIntersects | esriSpatialRelOverlaps | esriSpatialRelTouches | esriSpatialRelWithin | esriSpatialRelRelation
+        /// </summary>
         [DataMember(Name = "spatialRel")]
         public string SpatialRelationship { get; set; }
 

--- a/ArcGIS.Test/ArcGISGatewayTests.cs
+++ b/ArcGIS.Test/ArcGISGatewayTests.cs
@@ -189,6 +189,12 @@ namespace ArcGIS.Test
             Assert.True(resultPolygon.Features.All(i => i.Attributes != null && i.Attributes.Count == 4));
         }
 
+        /// <summary>
+        /// Performs unfiltered query, then filters by Extent and Polygon to SE quadrant of globe and verifies both filtered
+        /// results contain same number of features as each other, and that both filtered resultsets contain fewer features than unfiltered resultset.
+        /// </summary>
+        /// <param name="serviceUrl"></param>
+        /// <returns></returns>
         public async Task QueryGeometryCriteriaHonored(string serviceUrl)
         {
             int countAllResults = 0;
@@ -207,7 +213,6 @@ namespace ArcGIS.Test
             var queryPointExtentResults = new Query(serviceUrl.AsEndpoint())
             {
                 //Where = "1=1",
-
                 Geometry = new Extent() { XMin = 0, YMin = 0, XMax = 180, YMax = -90 }, // SE quarter of globe
                 //GeometryType = "esriGeometryEnvelope",
                 //SpatialRelationship = "esriSpatialRelIntersects"
@@ -243,12 +248,20 @@ namespace ArcGIS.Test
             Assert.True(countPolygonResults == countExtentResults);
         }
 
+        /// <summary>
+        /// Test geometry query against MapServer
+        /// </summary>
+        /// <returns></returns>
         [Fact]
         public async Task QueryMapServerGeometryCriteriaHonored()
         {
             await QueryGeometryCriteriaHonored(@"/Earthquakes/EarthquakesFromLastSevenDays/MapServer/0");
         }
 
+        /// <summary>
+        /// Test geometry query against FeatureServer
+        /// </summary>
+        /// <returns></returns>
         [Fact]
         public async Task QueryFeatureServerGeometryCriteriaHonored()
         {


### PR DESCRIPTION
Enable MapServer and FeatureServer queries to be filtered by a geometry.

Tested for Intersections with Extent and Polygon geometry types.
