### PR TITLE
Project shallow copy - tests to illustrate the issue

### DIFF
--- a/ArcGIS.Test/GeometryGatewayTests.cs
+++ b/ArcGIS.Test/GeometryGatewayTests.cs
@@ -22,6 +22,7 @@ namespace ArcGIS.Test
 
             Assert.NotNull(features);
             Assert.True(result.SpatialReference.Wkid != SpatialReference.WGS84.Wkid);
+            Assert.True(features[0].Geometry.Paths.Count > 0);
 
             if (result.SpatialReference.Wkid != SpatialReference.WGS84.Wkid)
             {
@@ -30,6 +31,8 @@ namespace ArcGIS.Test
                 Assert.NotNull(projectedFeatures);
                 Assert.Equal(features.Count, projectedFeatures.Count);
 
+                Assert.True(features[0].Geometry.Paths.Count > 0);  // If this fails, 2 issues: 1) features has been shallow copied, and 2) geometries aren't being populated.
+                Assert.True(projectedFeatures[0].Geometry.Paths.Count > 0); // If this fails, just problem 2 above - geometries aren't being copied.
                 Assert.NotEqual(features, projectedFeatures);
             }
         }


### PR DESCRIPTION
Dave,

Whilst adding a feature (separate pull request to come) I noticed that the Project code was creating a shallow copy of `features`, so the test comparing `features.Count` and `projectedFeatures.Count` will always return true.

Not an issue for me, but thought I'd share this pull request that adds three failing tests illustrating what I think the issue is.

Cheers
